### PR TITLE
fix rtd build failure

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,6 @@ myst_enable_extensions = [
   "colon_fence",
   "linkify",
   "replacements",
-  "linkify_fuzzy_links",
 ]
 
 autosummary_generate = True

--- a/docs/installations/installation-on-gnu-linux.md
+++ b/docs/installations/installation-on-gnu-linux.md
@@ -61,7 +61,7 @@ If you encounter errors with unavailable packages, troubleshoot using the follow
    ```
    Run the installation again.
 2. ICU with its `libicu` is missing.
-   You can find the missing version on [pkgs.org](https://pkgs.org) and install it with `gdebi`, too. You can have
+   You can find the missing version on pkgs.org and install it with `gdebi`, too. You can have
    multiple versions of ICU installed.
 3. Error while executing a tool
    To ensure the tool functionality, make sure you add the `OPENMS_DATA_PATH` variable to your environment as follow
@@ -97,16 +97,14 @@ Make sure you have [Docker installed](https://docs.docker.com/engine/install/).
 
 Our Docker support is constantly updated. Images can be obtained via [ghcr.io](https://ghcr.io).
 
-```{tab}
+```{tab} Executables
 
 [openms-executables](https://ghcr.io/openms/openms-executables:latest)
-
 ```
 
-```{tab}
+```{tab} Library
 
 [openms-library](https://ghcr.io/openms/openms-library:latest)
-
 ```
 
 Or via [BioContainers Registeries](https://biocontainers.pro/registry).

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sphinx-notfound-page
 sphinxcontrib-images
 sphinx-inline-tabs
 pygments
+linkify-it-py


### PR DESCRIPTION
if triggered build from a new branch rtd build errors. could be because
it builds all files not just changed.
https://readthedocs.org/projects/openms/builds/17572157/

Closes https://github.com/OpenMS/OpenMS-docs/issues/18.

(there were two errors in local, but the build was successful)


<img width="1532" alt="Screenshot 2022-07-29 at 6 17 27 PM" src="https://user-images.githubusercontent.com/4143778/181763709-e24de532-da11-42f9-911b-e05cc8b6f16f.png">

ReadTheDocs is not recognizing https://sphinx-inline-tabs.readthedocs.io/en/latest/usage.html#rich-tab-labels: 

```
/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/checkouts/rtd-build-errors/docs/advanced-resources/custom-compilation.md:8: WARNING: unknown node type: <_TabInput: >

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/sphinx/cmd/build.py", line 277, in build_main
    app.build(args.force_all, filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/sphinx/application.py", line 349, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 301, in build_update
    self.build(to_build,
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 367, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 559, in write
    self._write_serial(sorted(docnames))
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 569, in _write_serial
    self.write_doc(docname, doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/sphinx/builders/_epub_base.py", line 367, in write_doc
    super().write_doc(docname, doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/sphinx/builders/html/__init__.py", line 665, in write_doc
    self.docwriter.write(doctree, destination)
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/docutils/writers/__init__.py", line 78, in write
    self.translate()
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/sphinx/writers/html.py", line 59, in translate
    self.document.walkabout(visitor)
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/docutils/nodes.py", line 227, in walkabout
    if child.walkabout(visitor):
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/docutils/nodes.py", line 227, in walkabout
    if child.walkabout(visitor):
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/docutils/nodes.py", line 227, in walkabout
    if child.walkabout(visitor):
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/docutils/nodes.py", line 240, in walkabout
    visitor.dispatch_departure(self)
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/sphinx/util/docutils.py", line 583, in dispatch_departure
    super().dispatch_departure(node)
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/docutils/nodes.py", line 2034, in dispatch_departure
    return method(node)
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/docutils/nodes.py", line 2056, in unknown_departure
    raise NotImplementedError(
NotImplementedError: <class 'sphinx.writers.html5.HTML5Translator'> departing unknown node type: _TabInput

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/openms-staging/envs/rtd-build-errors/lib/python3.9/site-packages/docutils/nodes.py", line 2056, in unknown_departure
    raise NotImplementedError(
NotImplementedError: <class 'sphinx.writers.html5.HTML5Translator'> departing unknown node type: _TabInput
The full traceback has been saved in /tmp/sphinx-err-2btcsmzr.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!

```

<!--
# openms/openms-docs pull request

Thank you for thinking about contributing to OpenMS Documentation!

Please fill in the appropriate checklist below.

Remember that PRs should be made against the staging branch, unless you're preparing a hotfix to be released.

Learn more about contributing to OpenMS Documentation: https://staging-openms.readthedocs.io/en/staging/.github/CONTRIBUTING.html
-->

## Describe the change

<!-- Please add a brief description about the change in documentation that you're suggesting -->

## PR checklist

- [ ] I have added description of the change I'm proposing in the OpenMS Documentation.
- [ ] I have read and followed [OpenMS Documentation Contributing guidelines](CONTRIBUTING.md).
- [ ] I have attached a screenshot of the relevant area after this change.
- [ ] `CHANGELOG.md` is updated.
- [ ] I have added my name in [CONTRIBUTING.md](CONTRIBUTING.md#openms-documentation-contributors).
