### PR TITLE
Re-organize quick start guide locations

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,9 +72,9 @@ Contents
    :maxdepth: 2
    :caption: Tutorials and Quick Start Guides
 
+   tutorials-and-quickstart-guides/guides/user-quickstart-guide.md
    tutorials-and-quickstart-guides/openms-user-tutorial.md
    tutorials-and-quickstart-guides/tutorials.md
-   tutorials-and-quickstart-guides/quickstart-guides.md
 
 .. toctree::
    :maxdepth: 2
@@ -91,6 +91,7 @@ Contents
    :maxdepth: 2
    :caption: Contribute to OpenMS
 
+   tutorials-and-quickstart-guides/guides/contributors-quickstart-guide.md
    contribute-to-openms/openms-git-workflow.md
    contribute-to-openms/write-and-label-github-issues.md
    contribute-to-openms/adding-new-tool-to-topp.md

--- a/docs/tutorials-and-quickstart-guides/openms-user-tutorial.md
+++ b/docs/tutorials-and-quickstart-guides/openms-user-tutorial.md
@@ -51,7 +51,7 @@ On macOS, you run:
 - The KNIME installer: {{ '{path}'+'`Mac,knime_{0}.app.macosx.cocoa.x86_64.dmg`'.format(version) }}
 
 On Linux, you can extract KNIME to a folder of your choice and for TOPPView you need to install OpenMS via your package manager or build it on your own with our
-[build instructions](installations/installation-on-gnu-linux.md#build-openms-from-source).
+[build instructions](../installations/installation-on-gnu-linux.md#build-openms-from-source).
 
 :::
 
@@ -197,7 +197,8 @@ workflows. The first step is to become familiar with KNIME. Additional informati
 found on the KNIME [Getting Started page](https://www.knime.com/getting-started-guide). However, the most important
 concepts will also be reviewed in this tutorial.
 
-#### Plugin and dependency installation
+#### Plugin and dependency 
+
 
 Before we can start with the tutorial, we need to install all the required extensions for KNIME. Since KNIME 3.2.1, the program automatically
 detects missing plugins when you open a workflow but to make sure that the right source for the

--- a/docs/tutorials-and-quickstart-guides/openms-user-tutorial.md
+++ b/docs/tutorials-and-quickstart-guides/openms-user-tutorial.md
@@ -2558,7 +2558,7 @@ for iso in isotopes.getContainer():
     print (iso.getMZ(), ":", iso.getIntensity())
 ```
 
-For further examples and the pyOpenMS data structure please see the following [link](https://pyopenms.readthedocs.io/en/latest/datastructures_peak.html).
+For further examples and the pyOpenMS data structures please see the following [link](https://pyopenms.readthedocs.io/en/latest/ms_data.html).
 
 ### Tool development with pyOpenMS
 

--- a/docs/tutorials-and-quickstart-guides/openms-user-tutorial.md
+++ b/docs/tutorials-and-quickstart-guides/openms-user-tutorial.md
@@ -28,9 +28,9 @@ If you are doing this tutorial online, choose online in the following tab(s).
 If you are working through this tutorial at home/online, proceed with the following steps:
 
 - Download and install OpenMS using the installation instructions for your operating system:
-  - [GNU/Linux](/installations/installation-on-gnu-linux.md)
-  - [macOS](/installations/installation-on-macos.md)
-  - [Windows](/installations/installation-on-windows.md)
+  - [GNU/Linux](../installations/installation-on-gnu-linux.md)
+  - [macOS](../installations/installation-on-macos.md)
+  - [Windows](../installations/installation-on-windows.md)
 - Download and install [KNIME](https://www.knime.org/downloads/overview)
 
 :::

--- a/docs/tutorials-and-quickstart-guides/quickstart-guides.md
+++ b/docs/tutorials-and-quickstart-guides/quickstart-guides.md
@@ -1,9 +1,0 @@
-Quick Start Guides
-==================
-
-```{toctree}
-:maxdepth: 1
-
-guides/contributors-quickstart-guide.md
-guides/user-quickstart-guide.md
-```


### PR DESCRIPTION
Both user and contributors quick start guides were in the user tutorial section, accessible via a almost empty page that contained only two links. 

Here, the quick start guides are moved to their appropriate locations.

<!--
# openms/openms-docs pull request

Thank you for thinking about contributing to OpenMS Documentation!

Please fill in the appropriate checklist below.

Remember that PRs should be made against the staging branch, unless you're preparing a hotfix to be released.

Learn more about contributing to OpenMS Documentation: https://staging-openms.readthedocs.io/en/staging/.github/CONTRIBUTING.html
-->

## Describe the change

<!-- Please add a brief description about the change in documentation that you're suggesting -->

## PR checklist

- [ ] I have added description of the change I'm proposing in the OpenMS Documentation.
- [ ] I have read and followed [OpenMS Documentation Contributing guidelines](CONTRIBUTING.md).
- [ ] I have attached a screenshot of the relevant area after this change.
- [ ] `CHANGELOG.md` is updated.
- [ ] I have added my name in [CONTRIBUTING.md](CONTRIBUTING.md#openms-documentation-contributors).
