### PR TITLE
Fix link in dark mode

### DIFF
--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -60,7 +60,7 @@ Should you be missing something you can also add new functions or classes to the
             :margin: 0
 
             .. grid-item-card:: :material-regular:`account_tree;5em;sd-text-info` **Workflow Editor**
-                :link: /getting-started/webapps
+                :link: /getting-started/workflows
                 :link-type: doc
 
                 **Use a supported workflow editor to create or run predefined workflows.**

--- a/docs/getting-started/workflows.rst
+++ b/docs/getting-started/workflows.rst
@@ -93,7 +93,7 @@ workflow systems designed to make workflow creation and maintenance more fun:
 
     .. grid-item-card:: TOPPAS
         :img-top: /_images/introduction/TOPPAS_logo_dark.png
-        :link: /manual/develop
+        :link: /getting-started/toppas-get-started
         :link-type: doc
         :class-card: only-dark
         :class-img-top: halfwidth

--- a/docs/openms-applications-and-tools/visualize-with-openms/hotkeys-table.md
+++ b/docs/openms-applications-and-tools/visualize-with-openms/hotkeys-table.md
@@ -50,7 +50,7 @@ TOPPView Hotkeys
 
 | Hotkey                                   | Function                                            |
 |------------------------------------------|-----------------------------------------------------|
-| <kbd>CTRL</kbd> + <kbd>A</kbd>           | Select all annotations of the current layer         |
+| <kbd>CTRL</kbd> + <kbd>B</kbd>           | Select all annotations of the current layer         |
 | <kbd>DEL</kbd>                           | Delete all currently selected annotations           |
 
 


### PR DESCRIPTION
### **User description**
## Describe the change

Fix a link in dark mode

## PR checklist

- [ ] I have added description of the change I'm proposing in the OpenMS Documentation.
- [ ] I have read and followed [OpenMS Documentation Contributing guidelines](CONTRIBUTING.md).
- [ ] I have attached a screenshot of the relevant area after this change.
- [ ] `CHANGELOG.md` is updated.
- [ ] I have added my name in [CONTRIBUTING.md](CONTRIBUTING.md#openms-documentation-contributors).


___

### **PR Type**
enhancement


___

### **Description**
- Corrected the navigation link for TOPPAS in the dark mode documentation to ensure it directs users to the appropriate starting guide.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflows.rst</strong><dd><code>Update Link for TOPPAS in Dark Mode Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/getting-started/workflows.rst

<li>Updated the link for TOPPAS in the dark mode section to point to the <br>correct 'getting-started' page.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS-docs/pull/230/files#diff-b92c363255143d4043d3204ac700652bfab8f826d78758539f656b8f568f3625">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

