### PR TITLE
Add R version to conf.py for consistent documentation (#222)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -73,3 +73,4 @@ Finally, please add your name below:
 
 1. OpenMS Team
 2. Michael R. Crusoe
+3. Ayushmaan

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -12,3 +12,5 @@ http://dx.doi.org/*
 https://www.pnas.org/*
 http://pubs.acs.org/*
 https://www.sciencedirect.com/*
+https://cdash.seqan.de/index.php?project=OpenMS
+https://openms.de/current_doxygen/html/classOpenMS_1_1ConsensusFeature.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,8 @@ author = 'OpenMS Team'
 version = '3.3.0'
 # Short version for the latest supported KNIME
 knime_version = '5.3.0'
-
+# Short version for the Latest Supported R
+r_version = '4.2.3'
 # The full version, including alpha/beta/rc tags.
 release = '3.3.0'
 
@@ -143,7 +144,8 @@ pathicon = 'fa fa-folder-open'
 variables_to_export = [
     "project",
     "version",
-    "knime_version"
+    "knime_version",
+    "r_version"
 ]
 myst_substitutions = {}
 for v in variables_to_export:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ version = '3.3.0'
 # Short version for the latest supported KNIME
 knime_version = '5.3.0'
 # Short version for the Latest Supported R
-r_version = '4.2.3'
+r_version = '4.2.3' # <-- Added R version
 # The full version, including alpha/beta/rc tags.
 release = '3.3.0'
 
@@ -145,7 +145,7 @@ variables_to_export = [
     "project",
     "version",
     "knime_version",
-    "r_version"
+    "r_version" #<--
 ]
 myst_substitutions = {}
 for v in variables_to_export:


### PR DESCRIPTION
<!--
# openms/openms-docs pull request

Thank you for contributing to OpenMS Documentation!

Please fill in the appropriate checklist below.

PRs should be made against the development branch.
-->

## Describe the change

- Adds r_version (4.2.3) to conf.py
- Exports r_version in variables_to_export
- Resolves issue #222
![image](https://github.com/user-attachments/assets/b11a1de2-3b29-411c-93c0-2f30b67eb41d)
![image](https://github.com/user-attachments/assets/1096a688-8dd9-40e9-a0d0-b0cd669cdcfb)

<!-- Please add a brief description about the change in documentation that you're suggesting -->

## PR checklist

- [✅] I have added description of the change I'm proposing in the OpenMS Documentation.
- [✅] I have read and followed [OpenMS Documentation Contributing guidelines](/.github/CONTRIBUTING.md).
- [✅] I have attached a screenshot of the relevant area after this change.
- [ ] `CHANGELOG.md` is updated.
- [✅] I have added my name in [CONTRIBUTING.md](/.github/CONTRIBUTING.md#openms-documentation-contributors).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated contributor guidelines by adding a new contributor, Ayushmaan.
  - Enhanced documentation with supported R version information (4.2.3).
  - Expanded `.lycheeignore` to include additional URLs for exclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->